### PR TITLE
Force docker container arch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,8 @@
 # Define the argument before its first use
-FROM python:3.9-slim
+FROM --platform=linux/amd64 python:3.9-slim
 
 # get utilities in the container
 RUN apt-get update && apt-get install -y build-essential curl ssh git net-tools htop
-
-# Install Rust and Cargo
-# RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --no-modify-path
-RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain 1.80.1 --no-modify-path
-
-# Set the PATH environment variable to include Rust's bin directory
-ENV PATH="$PATH:/root/.cargo/bin"
 
 # Install pip dependencies
 RUN pip install --no-cache-dir --upgrade pip && pip install pandas jupyterlab


### PR DESCRIPTION
This would previously pull in aarch images when running on arm macs and we don't have builds for linux/aarch so it would attempt to build from source.

This isn't a problem when running outside the dev container since we have macos/aarch builds.

We can fix this on the glaredb side by just building for linux/aarch.